### PR TITLE
Update README.md with sentence & grammar fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # AWS Device Farm Catalogue
 
-This project is a Jenkins Pipeline script that lists the available devices in AWS DeviceFarm and creates a catalogue listing their most important characteristics and their ARN's. The idea is to make it easy for testers to find the ARN's of the devices they want to test on when using AWS DeviceFarm.
+This project is a Jenkins Pipeline script that lists the available devices in AWS DeviceFarm and creates a catalogue by listing their most important characteristics and ARN's. 
+
+The idea is to make it easy for testers to find the ARN's of the devices they want to test on when using AWS DeviceFarm.
 
 [The resulting catalogue can be found here](./catalogue-table.md)
 
 ## Context
 
-In order to run tests on AWS Device Farm, tester must first create *Device Pools*. If the tester has access to the AWS Console that seems easy enough. However in an environment where testers do not have that kind of access and/or if there's a need to automate the creation of the device pools, then using the AWS CLI command line utility is the alternative.
+To run tests on AWS Device Farm, a tester must first create *Device Pools* which is easy if the tester has an access to the AWS Console.
+If the tester do not have access to an environment and/or an automation of the device pool creation is needed, use the AWS CLI command line utility as an alternative.
 
-However, to create a device pools you'll need to configure selector rules in the payload of the [create-device-pool service](http://docs.aws.amazon.com/cli/latest/reference/devicefarm/create-device-pool.html) using the following syntax:
+To create a device pool, use the following syntax to configure selector rules in the payload of the [create-device-pool service](http://docs.aws.amazon.com/cli/latest/reference/devicefarm/create-device-pool.html):
 
 ```
 [
@@ -21,7 +24,7 @@ However, to create a device pools you'll need to configure selector rules in the
 ]
 ```
 
-Creating a device pool with rules based on platform, form factor or manufacturer can potentially result in very large pools, which will also produce very long -and expensive- tests. Creating a device pool of just a few hand-picked devices is desireable and reasonable for small feature developments or on B2E apps where the device models used are well known. However, creating a device pool based on the an *IN ARN* rule...
+Creating a device pool with rules based on platform, form factor or manufacturer can potentially result in a very large pool, which will also produce very long and expensive tests. Creating a device pool of just a few hand-picked devices is desireable and reasonable for small feature developments or on B2E apps where the device models used are well known. However, creating a device pool based on the an *IN ARN* rule...
 
 ```
 [
@@ -36,13 +39,14 @@ Creating a device pool with rules based on platform, form factor or manufacturer
 
 ... can be cumbersome since there's no public AWS Device Catalogue which lists the ARN's.
 
-The AWS Device Farm CLI command line utility does include a [list-devices service](http://docs.aws.amazon.com/cli/latest/reference/devicefarm/list-devices.html) which lists all available devices. Testers can then pick from the output the ARN's from the devices they want to test on and then must create payloads for the *create-device-pool* service by hand.
+The AWS Device Farm CLI command line utility does include a [list-devices service](http://docs.aws.amazon.com/cli/latest/reference/devicefarm/list-devices.html) which lists all available devices. 
+After the testers pick the ARN's to test, they must create payloads for the *create-device-pool* service by hand.
 
-This script just makes finding those ARN's less painfull, by updating the catalogue periodically and listing it in alphabetical order by the device's name.
+This script makes finding those ARN's less painful by updating the catalogue periodically and listing it in an alphabetical order by the device's name.
 
 ## Implementation Notes
 
-1. The cript assumes you'll place it in a repository that's accessible to your Jenkins server.
+1. The script assumes you'll place it in a repository that's accessible to your Jenkins server.
 2. The script assumes you've made AWS credentials available by using the [Jenkins Credentials Plugin](https://wiki.jenkins-ci.org/display/JENKINS/Credentials+Plugin)
 3. Make sure your password for Github doesn't contain '@'. If it does, the script will have no option but to url-encode it and Jenkins will write it encoded, but unmasked, to the log.
 4. The script assumes you've generated SSH keys for the Jenkins user to access your github account.


### PR DESCRIPTION
- Correct typo: cript -> script & painfull -> painful
- Revise confusing sentences: e.g. removing multiple "however"s in a small paragraph or restructuring sentences into more concise forms
- Correct minor grammatical errors: e.g. a device pools -> a device pool
- Change instructions to be more direct and clear: e.g. you'll need to do... -> Do this...
Fixes #4 